### PR TITLE
Fix empty image error in OpenCV

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
   "cSpell.words": [
+    "bboxes",
+    "binarize",
     "easyocr",
     "imread",
     "imshow",

--- a/src/taikoi2t/application/modal.py
+++ b/src/taikoi2t/application/modal.py
@@ -1,44 +1,60 @@
+import logging
 from typing import Sequence
 
 import cv2
 
-from taikoi2t.implements.image import show_image
+from taikoi2t.implements.image import sanitize_roi, show_image
 from taikoi2t.models.args import VERBOSE_IMAGE
 from taikoi2t.models.image import BoundingBox, Image
 
+logger: logging.Logger = logging.getLogger("taikoi2t.modal")
+
+RESULT_ASPECT_RATIO: float = 2.33
+ASPECT_RATIO_EPS: float = 0.05
+APPROX_PRECISION: float = 0.03
+
 
 def find_modal(grayscale: Image, verbose: int = 0) -> BoundingBox | None:
-    RESULT_ASPECT_RATIO: float = 2.33
-    ASPECT_RATIO_EPS: float = 0.05
-    APPROX_PRECISION: float = 0.03
-
-    source_width: int = grayscale.shape[1]
-
-    binary: Image = cv2.threshold(grayscale, 0, 255, cv2.THRESH_OTSU)[1]
-    contours, _ = cv2.findContours(binary, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
-
-    preview: Image | None = None
-    if verbose >= VERBOSE_IMAGE:
-        preview = cv2.cvtColor(binary, cv2.COLOR_GRAY2BGR)
-
     result: BoundingBox | None = None
-    for contour in contours:
-        epsilon: float = APPROX_PRECISION * cv2.arcLength(contour, True)  # type: ignore
-        approx = cv2.approxPolyDP(contour, epsilon, True)  # type: ignore
-        rect: Sequence[int] = cv2.boundingRect(approx)  # type: ignore
+    preview: Image | None = None
+    source_height, source_width = grayscale.shape[:2]
 
-        [left, top, width, height] = rect
-        if preview is not None:
-            cv2.drawContours(preview, [approx], -1, (0, 0, 255))
+    try:
+        binary: Image = cv2.threshold(grayscale, 0, 255, cv2.THRESH_OTSU)[1]
+        contours, _ = cv2.findContours(
+            binary, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
+        )
 
-        aspect_ratio: float = width / height
-        if (
-            width > source_width / 2
-            and abs(aspect_ratio - RESULT_ASPECT_RATIO) < ASPECT_RATIO_EPS
-        ):
-            result = BoundingBox(left, top, left + width, top + height)
+        if verbose >= VERBOSE_IMAGE:
+            preview = cv2.cvtColor(binary, cv2.COLOR_GRAY2BGR)
+
+        for contour in contours:
+            epsilon: float = APPROX_PRECISION * cv2.arcLength(contour, True)  # type: ignore
+            approx = cv2.approxPolyDP(contour, epsilon, True)  # type: ignore
+            if preview is not None:
+                cv2.drawContours(preview, [approx], -1, (0, 0, 255))
+
+            rect: Sequence[int] = cv2.boundingRect(approx)  # type: ignore
+            [left, top, width, height] = rect
+
+            aspect_ratio: float = width / height
+            if (
+                width > source_width / 2
+                and abs(aspect_ratio - RESULT_ASPECT_RATIO) < ASPECT_RATIO_EPS
+            ):
+                result = BoundingBox(
+                    left=left, top=top, right=left + width, bottom=top + height
+                )
+    except Exception as e:  # catch all errors from opencv
+        logger.error(e)
+
+    logger.debug(f"<Modal> => {result}")
 
     if preview is not None:
         show_image(preview)
 
-    return result
+    return (
+        sanitize_roi(result, image_width=source_width, image_height=source_height)
+        if result is not None
+        else None
+    )

--- a/src/taikoi2t/application/wins.py
+++ b/src/taikoi2t/application/wins.py
@@ -1,13 +1,21 @@
+import logging
+
 import cv2
 
 from taikoi2t.implements.image import crop, get_roi_bbox
 from taikoi2t.models.image import BoundingBox, Image, RelativeBox
+
+logger: logging.Logger = logging.getLogger("taikoi2t.wins")
 
 __PLAYER_WINS_RELATIVE = RelativeBox(left=1 / 12, top=1 / 5, right=1 / 6, bottom=1 / 4)
 
 
 def check_player_wins(colored_source: Image, modal: BoundingBox) -> bool:
     cropped = crop(colored_source, get_roi_bbox(modal, __PLAYER_WINS_RELATIVE))
-    mean_saturation: int = cv2.mean(cv2.cvtColor(cropped, cv2.COLOR_BGR2HSV))[1]
-    # 'Win' has more vivid color than 'Lose'
-    return mean_saturation > 50
+    try:
+        mean_saturation: int = cv2.mean(cv2.cvtColor(cropped, cv2.COLOR_BGR2HSV))[1]
+        # 'Win' has more vivid color than 'Lose'
+        return mean_saturation > 50
+    except Exception as e:
+        logger.error(e)
+        return False

--- a/src/taikoi2t/implements/ocr.py
+++ b/src/taikoi2t/implements/ocr.py
@@ -1,29 +1,26 @@
-from typing import Iterable, List, Sequence
+import logging
+from typing import Iterable, Sequence
 
-import cv2
 import easyocr  # type: ignore
 
-from taikoi2t.implements.image import crop, show_image
+from taikoi2t.implements.image import crop
 from taikoi2t.models.image import BoundingBox, Image
 from taikoi2t.models.ocr import Character
+
+logger: logging.Logger = logging.getLogger("taikoi2t.ocr")
 
 
 def read_text_from_roi(
     reader: easyocr.Reader, source: Image, roi: BoundingBox
 ) -> str | None:
     cropped: Image = crop(source, roi)
-    chars: Sequence[Character] = reader.readtext(cropped)  # type: ignore
-    return join_chars(chars) if len(chars) > 0 else None
+    try:
+        chars: Sequence[Character] = reader.readtext(cropped)  # type: ignore
+        return join_chars(chars) if len(chars) > 0 else None
+    except Exception as e:  # catch errors from easyocr and opencv
+        logger.error(e)
+        return None
 
 
 def join_chars(chars: Iterable[Character]) -> str:
     return "".join(c[1] for c in chars).replace(" ", "")
-
-
-# for debug
-def show_detection_result(image: Image, chars: List[Character]) -> None:
-    title: str = ""
-    for char in chars:
-        cv2.rectangle(image, char[0][0], char[0][2], 0, 1)
-        title += char[1]
-    show_image(image, title)

--- a/src/taikoi2t/models/image.py
+++ b/src/taikoi2t/models/image.py
@@ -21,6 +21,15 @@ class BoundingBox:
     def height(self) -> int:
         return abs(self.bottom - self.top)
 
+    def is_empty(self) -> bool:
+        return self.width == 0 or self.height == 0
+
+    # convert numpy integers
+    def as_python_int(self) -> "BoundingBox":
+        return BoundingBox(
+            int(self.left), int(self.top), int(self.right), int(self.bottom)
+        )
+
 
 @dataclass(frozen=True)
 class RelativeBox:

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,7 +1,21 @@
 from pathlib import Path
 
-from taikoi2t.implements.image import new_image_meta
-from taikoi2t.models.image import BoundingBox
+import numpy
+
+from taikoi2t.implements.image import crop, new_image_meta
+from taikoi2t.models.image import BoundingBox, Image
+
+
+def test_crop() -> None:
+    image1: Image = numpy.zeros((100, 200, 3), dtype=numpy.uint8)
+    res1 = crop(image1, BoundingBox(10, 0, 50, 80))
+    assert res1.shape == (80, 40, 3)
+
+    res2 = crop(image1, BoundingBox(-10, 0, 50, 180))
+    assert res2.shape == (100, 50, 3)
+
+    res3 = crop(image1, BoundingBox(120, 50, 20, 30))
+    assert res3.shape == (20, 100, 3)
 
 
 def test_new_image_meta(tmp_path: Path) -> None:


### PR DESCRIPTION
EasyOCR の文字検出が稀に画像の外側にはみ出した領域を返し, それを補正せず文字認識を行うと OpenCV 側から予期せぬ例外 (`error: (-215:Assertion failed) !_src.empty() in function 'cv::cvtColor'`) が発生してアプリ全体が異常終了するのを修正します.

動画内の字幕やタップエフェクトの重なりなど, リザルトウィンドウのバウンディングボックスが大きめに検出された際に生徒名検出の座標がずれることが原因とみています.

今後も予期せぬ例外が発生するのを見越し, コード全体に対して `easyocr`, `cv2` の機能を利用するセクションでは例外をすべてキャッチしログに書き, 処理を継続できるように変更を加えました.